### PR TITLE
Patches for Eureka Precisa and Acaia Pearl S

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This allows for easy extention of the library for more bluetooth enabled scales.
 
 * [Acaia Lunar](https://acaia.co/collections/coffee-scales/products/lunar_2021) - [Tested]
 * [Acaia Pearl](https://acaia.co/collections/coffee-scales/products/pearl) - [Tested]
+* [Acaia Pearl S](https://acaia.co/collections/coffee-scales/products/pearl-model-s) - [Tested]
 * [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/?coupon=gaggiuino) - [Tested]
 * [Decent Scale](https://decentespresso.com/decentscale) - [Tested]
 * [Difluid microbalance](https://digitizefluid.com/products/microbalance) - [Tested]

--- a/src/scales/acaia.cpp
+++ b/src/scales/acaia.cpp
@@ -153,7 +153,7 @@ bool AcaiaScales::decodeAndHandleNotification() {
 
     // For some reason, Acaia Pearl S sends this info message upon connection.
     // It can safely be ignored; otherwise, the scale will almost never successfully connect.
-    if(RemoteScales::getDeviceName().find("PEARLS")==0){
+    if(RemoteScales::getDeviceName().find("PEARLS")!=0){
       // This normally means that something went wrong with the establishing a connection so we disconnect.
       markedForReconnection = true;
     }

--- a/src/scales/acaia.cpp
+++ b/src/scales/acaia.cpp
@@ -149,12 +149,14 @@ bool AcaiaScales::decodeAndHandleNotification() {
     handleScaleStatusPayload(payload, payloadLength);
   }
   else if (messageType == AcaiaMessageType::INFO) {
-    std::string info_msg = RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength);
+    RemoteScales::log("Got info message: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+
     // For some reason, Acaia Pearl S sends this info message upon connection.
-    // Don't know what it means, but we can ignore it and it seems to work fine.
-    std::string ignore_msg = "EF DD 07 07 02 06 01 00 39 01 0E 3C ";
-    RemoteScales::log("Got info message: %s\n", info_msg.c_str());
-    if(info_msg.compare(ignore_msg) != 0){
+    // It can safely be ignored; otherwise, the scale will almost never successfully connect.
+    // "EF DD 07 07 02 06 01 00 39 01 0E 3C "
+    // This bug has only been confirmed with earlier model Pearl S and only one example unit.
+    // More data is required...
+    if(!RemoteScales::getDeviceName().find("PEARLS")){
       // This normally means that something went wrong with the establishing a connection so we disconnect.
       markedForReconnection = true;
     }

--- a/src/scales/acaia.cpp
+++ b/src/scales/acaia.cpp
@@ -153,10 +153,7 @@ bool AcaiaScales::decodeAndHandleNotification() {
 
     // For some reason, Acaia Pearl S sends this info message upon connection.
     // It can safely be ignored; otherwise, the scale will almost never successfully connect.
-    // "EF DD 07 07 02 06 01 00 39 01 0E 3C "
-    // This bug has only been confirmed with earlier model Pearl S and only one example unit.
-    // More data is required...
-    if(!RemoteScales::getDeviceName().find("PEARLS")){
+    if(RemoteScales::getDeviceName().find("PEARLS")==0){
       // This normally means that something went wrong with the establishing a connection so we disconnect.
       markedForReconnection = true;
     }

--- a/src/scales/acaia.cpp
+++ b/src/scales/acaia.cpp
@@ -149,9 +149,16 @@ bool AcaiaScales::decodeAndHandleNotification() {
     handleScaleStatusPayload(payload, payloadLength);
   }
   else if (messageType == AcaiaMessageType::INFO) {
-    RemoteScales::log("Got info message: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
-    // This normally means that something went wrong with the establishing a connection so we disconnect.
-    markedForReconnection = true;
+    std::string info_msg = RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength);
+    // For some reason, Acaia Pearl S sends this info message upon connection.
+    // Don't know what it means, but we can ignore it and it seems to work fine.
+    std::string ignore_msg = "EF DD 07 07 02 06 01 00 39 01 0E 3C ";
+    RemoteScales::log("Got info message: %s\n", info_msg.c_str());
+    if(info_msg.compare(ignore_msg) != 0){
+      // This normally means that something went wrong with the establishing a connection so we disconnect.
+      markedForReconnection = true;
+    }
+    
   }
   else {
     RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());

--- a/src/scales/eureka.h
+++ b/src/scales/eureka.h
@@ -56,6 +56,6 @@ private:
     const std::string& deviceData = device.getManufacturerData();
     char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
     std::string md(pHex);
-    return !md.empty() && deviceName.empty() && (md.find("0000a6bc") != std::string::npos || md.find("042") == 0);
+    return !md.empty() && deviceName.empty() && (md.find("a6bc") != std::string::npos || md.find("042") == 0);
   }
 };


### PR DESCRIPTION
Fixes detection issue with newer Eureka Precisa (white emblem) and disconnection with older Acaia Pearl model S. 