### PR TITLE
Add heartbeat support for Decent Scale based on Decent docs

### DIFF
--- a/src/scales/decent.h
+++ b/src/scales/decent.h
@@ -22,6 +22,9 @@ private:
 
   bool markedForReconnection = false;
 
+  unsigned long lastHeartbeatMillis = 0;
+  void sendHeartbeat();
+
   void readCallback(NimBLERemoteCharacteristic* pCharacteristic, uint8_t* pData,
     size_t length, bool isNotify);
 


### PR DESCRIPTION
According to the Decent guide [here](https://decentespresso.com/docs/programmers_guide_to_the_half_decent_scale) the new firmware requires a heartbeat (5s) for keepalive.

Added heartbeat
Updated Tare function to send 0x01 to use heartbeat