### PR TITLE
feat: upgrade NimBLE-Arduino to 2.5.0 and add pioarduino (Arduino ESP32 3.x) env

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,17 @@
+{
+  "name": "esp-arduino-ble-scales",
+  "description": "Bluetooth scales library for ESP32 on Arduino framework. Supports Acaia, Bookoo, Decent, Difluid, Eclair, Felicita, Timemore, Varia, and more.",
+  "keywords": ["ble", "bluetooth", "scales", "esp32", "nimble"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gaggimate/esp-arduino-ble-scales"
+  },
+  "frameworks": ["arduino"],
+  "platforms": ["espressif32"],
+  "dependencies": {
+    "h2zero/NimBLE-Arduino": "^2.5.0"
+  },
+  "build": {
+    "srcFilter": "+<*> -<main.cpp>"
+  }
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,16 +8,23 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:test]
+[common]
 framework = arduino
-platform = https://github.com/platformio/platform-espressif32.git
 build_flags =
 	-std=gnu++2a
 	-frtti
 board = lolin_s3
 lib_deps =
-	ArduinoFake
-	h2zero/NimBLE-Arduino@^1.4.1
+	h2zero/NimBLE-Arduino@^2.5.0
 lib_compat_mode = off
 build_unflags =
 	-std=gnu++11
+
+[env:test]
+extends = common
+platform = https://github.com/platformio/platform-espressif32.git
+
+; Matches gaggimate downstream pin (jniebuhr/gaggimate#676).
+[env:test-pioarduino]
+extends = common
+platform = https://github.com/pioarduino/platform-espressif32.git#55.03.38-1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,7 @@
+// Minimal entry point for compile-check build environment.
+// This project is a library; this file exists only to satisfy the Arduino
+// framework's requirement for setup() and loop() when building with pio run.
+#include <Arduino.h>
+
+void setup() { /* No-op: library has no standalone initialization */ }
+void loop() { /* No-op: library has no standalone run loop */ }

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -97,13 +97,13 @@ void RemoteScalesScanner::initializeAsyncScan() {
   // We set the second parameter to true to prevent the library from storing BLEAdvertisedDevice objects
   // for devices we're not interested in. This is important because the library will otherwise run out of
   // memory after a while.
-  NimBLEDevice::getScan()->setAdvertisedDeviceCallbacks(this, true);
+  NimBLEDevice::getScan()->setScanCallbacks(this, true);
   NimBLEDevice::getScan()->setInterval(500);
   NimBLEDevice::getScan()->setWindow(100);
   NimBLEDevice::getScan()->setMaxResults(0);
   NimBLEDevice::getScan()->setDuplicateFilter(false);
   NimBLEDevice::getScan()->setActiveScan(true);
-  NimBLEDevice::getScan()->start(0, nullptr, false); // Set to 0 for continuous
+  NimBLEDevice::getScan()->start(0, false); // Set to 0 for continuous
   isRunning = true;
 }
 
@@ -120,8 +120,8 @@ void RemoteScalesScanner::restartAsyncScan() {
   initializeAsyncScan();
 }
 
-void RemoteScalesScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
-  if (std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getNative()), 6); alreadySeenAddresses.exists(addrStr)) {
+void RemoteScalesScanner::onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
+  if (std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getVal()), 6); alreadySeenAddresses.exists(addrStr)) {
     return;
   }
   if (RemoteScalesPluginRegistry::getInstance()->containsPluginForDevice(advertisedDevice)) {

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -8,7 +8,7 @@
 
 class DiscoveredDevice {
 public:
-  DiscoveredDevice(NimBLEAdvertisedDevice* device) :
+  DiscoveredDevice(const NimBLEAdvertisedDevice* device) :
   name(device->getName()), address(device->getAddress()), manufacturerData(device->getManufacturerData()), rssi(device->getRSSI()) {}
   const std::string& getName() const { return name; }
   const NimBLEAddress& getAddress() const { return address; }
@@ -70,13 +70,13 @@ private:
 // ---------------------------------------------------------------------------------------
 // ---------------------------   RemoteScalesScanner    -----------------------------------
 // ---------------------------------------------------------------------------------------
-class RemoteScalesScanner : public NimBLEAdvertisedDeviceCallbacks {
+class RemoteScalesScanner : public NimBLEScanCallbacks {
 private:
   bool isRunning = false;
   LRUCache alreadySeenAddresses = LRUCache(100);
   std::vector<DiscoveredDevice> discoveredScales;
   void cleanupDiscoveredScales();
-  void onResult(NimBLEAdvertisedDevice* advertisedDevice) override;
+  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
 
 public:
   std::vector<DiscoveredDevice> getDiscoveredScales() { return discoveredScales; }

--- a/src/scales/acaia.cpp
+++ b/src/scales/acaia.cpp
@@ -329,18 +329,6 @@ bool AcaiaScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe to notifications
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x01, 0x00 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   // Identify
   sendId();
   RemoteScales::log("Send ID\n");

--- a/src/scales/bookoo.cpp
+++ b/src/scales/bookoo.cpp
@@ -158,18 +158,6 @@ bool BookooScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x00, 0x01 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   sendNotificationRequest();
   RemoteScales::log("Sent notification request\n");
   lastHeartbeat = millis();

--- a/src/scales/eureka.h
+++ b/src/scales/eureka.h
@@ -54,8 +54,7 @@ private:
       return true;
     }
     const std::string& deviceData = device.getManufacturerData();
-    char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
-    std::string md(pHex);
+    std::string md = NimBLEUtils::dataToHexString((uint8_t*)deviceData.c_str(), deviceData.length());
     return !md.empty() && deviceName.empty() && (md.find("a6bc") != std::string::npos || md.find("042") == 0);
   }
 };

--- a/src/scales/myscale.cpp
+++ b/src/scales/myscale.cpp
@@ -82,19 +82,13 @@ bool myscale::performConnectionHandshake() {
         return false;
     }
 
-    if (dataCharacteristic->canNotify()) {
-        auto cccd = dataCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-        if (cccd) {
-            uint8_t notifyOn[] = {0x01, 0x00};
-            cccd->writeValue(notifyOn, 2, true); // enable notifications
-        }
-        dataCharacteristic->subscribe(true, [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
-            notifyCallback(characteristic, data, length, isNotify);
-        });
-    } else {
+    if (!dataCharacteristic->canNotify()) {
         log("Notifications not supported.\n");
         return false;
     }
+    dataCharacteristic->subscribe(true, [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+        notifyCallback(characteristic, data, length, isNotify);
+    });
 
     // Cache write characteristic once to avoid blocking discovery during tare
     writeCharacteristic = service->getCharacteristic(WRITE_CHARACTERISTIC_UUID);

--- a/src/scales/timemore.cpp
+++ b/src/scales/timemore.cpp
@@ -134,18 +134,6 @@ bool TimemoreScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x01, 0x00 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   sendNotificationRequest();
   RemoteScales::log("Sent notification request\n");
   lastHeartbeat = millis();

--- a/src/scales/weighmybru.cpp
+++ b/src/scales/weighmybru.cpp
@@ -156,18 +156,6 @@ bool WeighMyBrewScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x00, 0x01 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   sendNotificationRequest();
   RemoteScales::log("Sent notification request\n");
   lastHeartbeat = millis();


### PR DESCRIPTION
## Summary

Upgrades NimBLE-Arduino to 2.x (unlocks Arduino ESP32 3.x) and adds a pioarduino build environment, while staying compatible with the stock PlatformIO platform.

- **NimBLE-Arduino `^2.5.0`** — required for Arduino ESP32 3.x. Scan-callbacks migration (`NimBLEScanCallbacks`), `const NimBLEAdvertisedDevice*`, `NimBLEAddress::getVal()`, 2-arg `NimBLEScan::start()`, `NimBLEUtils::dataToHexString()`.
- **Drop manual CCCD (`0x2902`) `writeValue` blocks** in acaia/bookoo/timemore/weighmybru/myscale — `subscribe(true, cb)` already writes the CCCD on NimBLE-Arduino >= 1.4. Removes a latent byte-order bug in bookoo and weighmybru (`{0x00,0x01}` = indications vs `{0x01,0x00}` = notifications) that was masked by the subsequent `subscribe()` call.
- **New `[env:test-pioarduino]`** using [pioarduino/platform-espressif32](https://github.com/pioarduino/platform-espressif32) pinned to `55.03.38-1` (matches downstream consumer [jniebuhr/gaggimate#676](https://github.com/jniebuhr/gaggimate/pull/676)). Community platform is needed for Arduino ESP32 3.x / IDF 5.x — the official PlatformIO platform is stuck at 2.0.17.
- **Factor shared env fields into `[common]`**; both `[env:test]` and `[env:test-pioarduino]` inherit via `extends`.
- **`library.json`** with `srcFilter` so downstream consumers that pull this library via `lib_deps` don't trip over the stub `main.cpp`'s `setup()`/`loop()`.

## Platform compatibility

NimBLE-Arduino 2.5.0 builds against **both** toolchains — NimBLE's own CI matrix compiles 2.5.0 against stock `platform-espressif32` (arduino-esp32 2.0.17 / IDF 4.4.x) and pioarduino (arduino-esp32 3.x / IDF 5.x) in parallel. The 1.x -> 2.x API changes in this PR are NimBLE-internal, not tied to the Arduino core version.

| env | platform | Arduino core | IDF | boards |
|---|---|---|---|---|
| `test` | stock `platform-espressif32` | 2.0.17 | 4.4.x | esp32 / s3 / c3 |
| `test-pioarduino` | pioarduino `55.03.38-1` | 3.3.8 | 5.5.4 | + esp32-c6 / h2 / c2 / c5 |

Stock env is retained for existing consumers on arduino-esp32 2.x. Only downstream projects on newer chips (c6/h2/c2/c5) or that require IDF 5.x must use pioarduino.

## Sonar

Previous run flagged 18.6% duplicated new code. Addressed by:
- Deduping the two `[env:...]` sections via `[common]` + `extends`.
- Removing the five duplicated manual-CCCD blocks in scale drivers.

## Test plan

- [x] `pio run -e test` compiles (stock platform, arduino-esp32 2.0.17)
- [x] `pio run -e test-pioarduino` compiles (pioarduino 55.03.38-1, arduino-esp32 3.3.8 / IDF 5.5.4)
- [x] Spot-check on hardware

Co-Authored-By: [Claude Code](https://claude.com/claude-code)