### PR TITLE
fix: free buildHexData buffer in EurekaScalesPlugin::handles (per-advertisement heap leak)

### DIFF
--- a/src/scales/eureka.h
+++ b/src/scales/eureka.h
@@ -55,7 +55,11 @@ private:
     }
     const std::string& deviceData = device.getManufacturerData();
     char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
+    if (pHex == nullptr) {
+      return false;
+    }
     std::string md(pHex);
+    free(pHex); // buildHexData(target=nullptr,...) malloc's and transfers ownership; must free or it leaks per advertisement
     return !md.empty() && deviceName.empty() && (md.find("a6bc") != std::string::npos || md.find("042") == 0);
   }
 };


### PR DESCRIPTION
## Problem

`EurekaScalesPlugin::handles()` (`src/scales/eureka.h`) calls `NimBLEUtils::buildHexData(nullptr, …)`, which `malloc`s a `length*2+1` byte buffer and **transfers ownership to the caller**. The buffer is copied into a `std::string` but never freed:

```cpp
char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
std::string md(pHex);   // copies…
return ...;              // …pHex leaked
```

`RemoteScalesScanner` scans continuously (`start(0)`), and `handles()` runs for **every advertisement** the registry evaluates. A host left scanning for hours therefore leaks one allocation per ambient BLE advertisement. On an ESP32-S3 display board this slowly exhausts the heap until the async network stack can no longer allocate connection buffers and the web UI becomes unreachable until reboot.

## Fix

Free the buffer after copying it, and guard the rare `malloc`-failure case so `std::string` is never constructed from a null pointer:

```cpp
char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
if (pHex == nullptr) {
  return false;
}
std::string md(pHex);
free(pHex);
```

No behavioral change beyond freeing an already-copied buffer.

## How it was found

Linker `-Wl,--wrap=malloc/free/calloc/realloc` allocation backtraces + addr2line on a downstream ESP32-S3 firmware pinpointed the surviving allocation to `EurekaScalesPlugin::handles → NimBLEUtils::buildHexData`.

## Verification

Reproduced on a LilyGo-T-RGB build with a harness firing a scan cycle every 3 s:

- **Before:** allocated blocks climbed monotonically (~+9/cycle); OOM-wedged in ~6 min.
- **After:** flat across a full 40-cycle run; heap steady, no growth.