### PR TITLE
feat(dot): decode battery level

### DIFF
--- a/src/scales/dot.cpp
+++ b/src/scales/dot.cpp
@@ -164,6 +164,11 @@ bool TimemoreDotScales::decodeAndHandleNotification() {
                   (static_cast<int32_t>(dataBuffer[8]) << 8)  |
                    static_cast<int32_t>(dataBuffer[9]);
     RemoteScales::setWeight(raw / 10.0f);
+  } else if (cls == 0x01 && type == 0x05 && payloadLen == 2) {
+    // Battery frame, emitted roughly every 30 s. payload[0] has been observed
+    // as a fixed 0x02 prefix (likely a status/category code); payload[1] is
+    // battery percentage 0-100.
+    RemoteScales::setBatteryLevel(dataBuffer[7]);
   } else {
     RemoteScales::log("Unhandled frame cls=%02X type=%02X len=%u\n",
                       cls, type, (unsigned)payloadLen);

--- a/src/scales/dot.h
+++ b/src/scales/dot.h
@@ -16,6 +16,8 @@ public:
   bool isConnected() override;
   bool tare() override;
 
+  bool hasBatteryLevel() const override { return true; }
+
 private:
   bool markedForReconnection = false;
 


### PR DESCRIPTION
## Summary

The Dot's FFF1 stream emits a battery frame approximately every 30 s, interleaved with the weight stream. Decode it and surface the value via the existing `RemoteScales::setBatteryLevel()` path, with `hasBatteryLevel()` overridden so consumers can rely on the reading.

## Frame format

\`\`\`
A5 5A 01 05 00 02 02 XX 00 00
\`\`\`

- `cls=0x01`, `type=0x05`, `payloadLen=0x0002`
- `payload[0]` = `0x02` in every capture (likely a status/category code; not surfaced)
- `payload[1]` = battery percentage 0..100, plain integer

## Why this and not the vendor service

The Dot also exposes a separate vendor service (`5833FF01-9B8B-5191-6142-22A4536EF123`) whose notify characteristic (`5833FF03-...`) returns the same percentage as a single `uint8`. Decoding from the existing FFF1 subscription avoids opening a second characteristic and adding a second subscribe round-trip on connect.

## Validation

Captured via nRF Connect against a real Timemore Dot while the Timemore app was concurrently connected (the Dot supports multi-central):

- Timemore app reported 74 % at session start
- A few minutes later, FFF1 emitted `... 01 05 00 02 02 45 ...` → `0x45 = 69`
- Some minutes after that, `... 01 05 00 02 02 44 ...` → `0x44 = 68`

Both readings track the natural discharge curve the Timemore app showed.

## Status

Draft for review.